### PR TITLE
docs: add staging Forge deployment runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,14 @@ STATION_DEMO_GRACE_DAYS=7
 # APP_DEBUG=false
 # APP_URL=https://fissible.dev
 
+# Staging overrides:
+# APP_ENV=staging
+# APP_DEBUG=true
+# APP_URL=https://staging.fissible.dev
+# STATION_PLATFORM_ENABLED=true
+# STATION_PLATFORM_HOST=staging-app.fissible.dev
+# STATION_MANAGED_ROOT_DOMAIN=staging.fissible.dev
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/apps/docs/src/content/docs/station/theme-reference.md
+++ b/apps/docs/src/content/docs/station/theme-reference.md
@@ -1,0 +1,185 @@
+---
+title: Theme Reference
+description: Reference for the theme.json schema, CSS variable types, artisan commands, and configuration keys used by the Station theme system.
+sidebar:
+  order: 62
+---
+
+Reference material for building and operating Station themes.
+
+## `theme.json` schema
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `name` | string | Yes | 1–100 chars. |
+| `slug` | string | Yes | Lowercase alphanumeric + hyphens. Must match the directory name. |
+| `version` | string | Yes | Valid semver (e.g., `1.0.0`). |
+| `theme_api` | integer | Yes | ≥ 1. |
+| `tier` | string | Yes | One of: `free`, `premium`. |
+| `author` | string | Yes | Any string. |
+| `station_requires` | string | Yes | Composer-style constraint (e.g., `>=0.5.0`). |
+| `variables` | object | Yes | Keys start with `--`. Each value is `{ type, default }`. |
+| `templates` | array<string> | Yes | Non-empty. Each entry must correspond to `views/{name}.blade.php`. |
+| `variant` | string | No | Sub-identifier (e.g., `warm`, `bold`). |
+| `suite` | string | No | Theme family identifier. |
+| `description` | string | No | Long-form description. |
+| `preview` | string | No | Path to preview image relative to theme root. |
+| `logo` | object | No | `{ max_height?, max_width?, hint? }` — displayed in Site Settings to guide logo uploads. |
+
+## Variable types
+
+| Type | Admin UI | Accepted values |
+|------|---------|-----------------|
+| `color` | Color picker | Hex (`#RGB`, `#RRGGBB`, `#RRGGBBAA`), `rgb()`, `rgba()`, `hsl()`, `hsla()`, `oklch()`, named colors. |
+| `font` | Text input (max 200 chars) | Font-family stack. Rejects `;`, `{`, `}`, `(`, `)`, `url(`, `@`, `expression(`. |
+| `dimension` | Text input | Number with unit: `px`, `rem`, `em`, `%`, `vh`, `vw`, `vmin`, `vmax`, `ch`, `ex`. |
+
+Any override value that fails validation is silently dropped from the rendered CSS.
+
+## Required views
+
+These are required in every theme — validation fails without them:
+
+- `views/layout.blade.php`
+- `views/homepage.blade.php`
+- `views/list.blade.php`
+- `views/detail.blade.php`
+
+Declared in `templates` but missing the view file is a **warning**, not an error.
+
+## Reconciliation rules
+
+| Disk state | DB state | Action |
+|------------|---------|--------|
+| Valid theme exists | No row | Create row, `status=available`. |
+| Valid theme exists | Row, any status | Set `status=available`, refresh `cached_metadata`, touch `last_seen_at`. |
+| No theme on disk | Row, `status=available` | Set `status=missing`, log warning. |
+| No theme on disk | Row, `removed_at` set | No change (intentional removal). |
+| Theme exists but invalid | Any | Set `status=invalid`, populate `validation_errors`. |
+| Theme returns to disk | Row, `status=missing` | Set `status=available`, clear `validation_errors`. |
+| Same slug in multiple paths | — | Both flagged; slug marked `invalid`. |
+
+## Resolution chain
+
+When the frontend asks for a tenant's active theme, Station resolves it in this order:
+
+1. `site_settings.frontend_theme` for the tenant.
+2. `STATION_THEME` environment variable.
+3. `'heartland'` system default.
+4. First available theme (last resort).
+
+Each fallback emits a `FallbackReason`:
+
+| Reason | Cause |
+|--------|-------|
+| `none` | Tenant setting resolved successfully. |
+| `missing` | Tenant setting points at a slug that does not exist on disk. |
+| `invalid` | Tenant setting points at an invalid theme. |
+| `removed` | Tenant setting points at a soft-removed theme. |
+| `env_default` | No tenant setting; fell back to env var. |
+| `system_default` | No tenant setting, no env; fell back to `heartland`. |
+
+## Artisan commands
+
+### `station:make-theme {slug}`
+
+Scaffold a new theme in the primary writable theme path.
+
+```bash
+php artisan station:make-theme acme
+```
+
+Creates `themes/acme/` with a valid `theme.json`, required views, a starter `assets/app.css`, and runs reconciliation. Fails if the directory already exists or the slug is invalid.
+
+### `station:theme:reconcile [--slug=]`
+
+Reconcile theme registry with filesystem state.
+
+```bash
+php artisan station:theme:reconcile                # full sweep
+php artisan station:theme:reconcile --slug=acme    # single theme
+```
+
+Outputs a `ReconcileReport` with counts of created, updated, missing, invalid, and recovered themes.
+
+### `station:theme:list`
+
+List all installed themes with source, status, version, and tenant usage.
+
+```bash
+php artisan station:theme:list
+```
+
+### `station:packages:refresh`
+
+Sync the package registry from the remote feed (for Composer-installable themes).
+
+```bash
+php artisan station:packages:refresh
+```
+
+Requires `station.themes.registry_url` to be configured.
+
+### `theme:set-default {slug}`
+
+Legacy command. Writes `STATION_THEME` to `.env`. Per-tenant themes from Site Settings take precedence.
+
+## Configuration keys
+
+From `config/station.php`:
+
+```php
+'theme' => env('STATION_THEME', 'heartland'),
+
+'themes' => [
+    'paths' => [
+        base_path('themes'),  // primary writable path (first) + any additional paths
+    ],
+    'max_upload_size' => 10 * 1024 * 1024,  // 10MB
+    // 'registry_url' => 'https://registry.example.com/themes.json',
+],
+```
+
+| Key | Purpose |
+|-----|---------|
+| `station.theme` | Env-default theme slug used when a tenant has no `frontend_theme`. |
+| `station.themes.paths` | Array of directories scanned for themes. First path is the primary writable target. |
+| `station.themes.max_upload_size` | Max bytes for zip uploads. |
+| `station.themes.registry_url` | Optional remote feed URL for the package registry. |
+
+## Zip upload security
+
+| Check | Rule |
+|-------|------|
+| File size | ≤ `max_upload_size` (default 10MB). |
+| Path traversal | Reject any entry containing `../`. |
+| Allowed extensions | `.blade.php`, `.css`, `.js`, `.json`, `.jpg`, `.jpeg`, `.png`, `.svg`, `.webp`, `.woff`, `.woff2`, `.txt`, `.md`. |
+| PHP files | Only in `views/`, only `.blade.php`. |
+| Executable files | Rejected. |
+| Symlinks | Rejected. |
+| Structure | `theme.json`, `views/`, `assets/` required. |
+| Slug match | `theme.json.slug` must match archive root directory name. |
+
+## Scheduled tasks
+
+Station registers two scheduled commands automatically:
+
+| Command | Cadence |
+|---------|---------|
+| `station:theme:reconcile` | Daily at 03:30 |
+| `station:packages:refresh` | Daily at 04:30 |
+
+## Data model
+
+| Table | Scope | Purpose |
+|-------|-------|---------|
+| `installed_themes` | Platform | Authoritative list of known themes with source, status, and staleness info. |
+| `theme_overrides` | Tenant | CSS variable overrides per `(tenant_id, theme_slug)`. |
+| `available_packages` | Platform | Curated Composer packages available for install. |
+| `site_settings.frontend_theme` | Tenant | Tenant's selected theme slug (nullable, not an FK). |
+
+## Related guides
+
+- [Theme development](/station/themes/) — building a theme from scratch.
+- [Frontend & theming](/station/frontend-theming/) — template rendering, editorial bar, SEO.
+- [Configuration](/station/configuration/) — environment variables and config keys.

--- a/apps/docs/src/content/docs/station/themes.md
+++ b/apps/docs/src/content/docs/station/themes.md
@@ -1,0 +1,261 @@
+---
+title: Theme Development
+description: Build custom Station themes. Covers theme structure, the theme.json contract, CSS variables, templates, distribution, and the theme API.
+sidebar:
+  order: 61
+---
+
+Station themes drive frontend rendering. Each tenant picks its own theme from the available set, and can override the theme's CSS variables without touching the theme files. This guide shows how to build a new theme from scratch.
+
+## Quick start
+
+Scaffold a theme with the built-in artisan command:
+
+```bash
+php artisan station:make-theme acme
+```
+
+This creates `themes/acme/` with a valid `theme.json`, the required Blade views, and a starter `assets/app.css`. Station runs a reconciliation pass, so the theme is immediately available in the Site Settings theme selector.
+
+## Theme structure
+
+Every theme lives in a single directory with this layout:
+
+```
+themes/acme/
+  theme.json          # Required manifest
+  views/
+    layout.blade.php      # Required — base layout
+    homepage.blade.php    # Required — homepage template
+    list.blade.php        # Required — content type listing
+    detail.blade.php      # Required — entry detail
+    page.blade.php        # Optional — page template
+    partials/             # Optional — reusable partials
+  assets/
+    app.css               # Theme stylesheet (served at /themes/{slug}/app.css)
+  preview.jpg            # Optional — preview image
+```
+
+**Required views:** `layout.blade.php`, `homepage.blade.php`, `list.blade.php`, `detail.blade.php`. Missing any of these causes validation to fail and the theme is flagged as `invalid`.
+
+## The `theme.json` contract
+
+The manifest declares the theme's identity, CSS variables, and available templates.
+
+```json
+{
+  "name": "Acme",
+  "slug": "acme",
+  "version": "1.0.0",
+  "theme_api": 1,
+  "variant": "default",
+  "tier": "free",
+  "description": "A clean, modern theme for Station.",
+  "author": "Acme Studios",
+  "station_requires": ">=0.5.0",
+  "preview": "preview.jpg",
+  "variables": {
+    "--color-accent":     { "type": "color",     "default": "#2563EB" },
+    "--color-text":       { "type": "color",     "default": "#1A1A2E" },
+    "--color-background": { "type": "color",     "default": "#FFFFFF" },
+    "--font-body":        { "type": "font",      "default": "system-ui, sans-serif" },
+    "--max-width":        { "type": "dimension", "default": "1100px" }
+  },
+  "templates": ["layout", "homepage", "list", "detail", "page"]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable name, 1–100 chars. |
+| `slug` | Yes | Lowercase letters, digits, hyphens. Must match the directory name. |
+| `version` | Yes | Semver. |
+| `theme_api` | Yes | Integer ≥ 1. The Station theme contract version the theme targets. |
+| `tier` | Yes | `free` or `premium`. |
+| `author` | Yes | String. |
+| `station_requires` | Yes | Composer-style constraint (e.g., `>=0.5.0`). |
+| `variables` | Yes | CSS variable declarations — see below. |
+| `templates` | Yes | Non-empty list of template names. Each should map to `views/{name}.blade.php`. |
+| `variant` | No | Optional sub-identifier (e.g., `warm`, `bold`). |
+| `preview` | No | Path to a preview image relative to the theme root. |
+| `description` | No | Long-form description. |
+
+## CSS variables
+
+Variables declared in `theme.json` can be overridden per-tenant from the Site Settings admin page.
+
+### Declaring variables
+
+```json
+"variables": {
+  "--color-accent": { "type": "color",     "default": "#2563EB" },
+  "--font-body":    { "type": "font",      "default": "Georgia, serif" },
+  "--max-width":    { "type": "dimension", "default": "1100px" }
+}
+```
+
+Supported types:
+
+| Type | Admin UI | Validation |
+|------|---------|------------|
+| `color` | Color picker | Any valid CSS color (hex, rgb, hsl, oklch, named colors). |
+| `font` | Text input (200 char max) | Rejects `;`, `{`, `}`, `(`, `)`, `url(`, `@`, `expression(`. |
+| `dimension` | Text input | `px`, `rem`, `em`, `%`, `vh`, `vw`, `vmin`, `vmax`, `ch`, `ex`. |
+
+Keys must start with `--`. Invalid keys or types fail validation.
+
+### Defaults in the stylesheet
+
+Declare the defaults in `assets/app.css` so the theme works without any overrides:
+
+```css
+:root {
+  --color-accent: #2563EB;
+  --color-text: #1A1A2E;
+  --color-background: #FFFFFF;
+  --font-body: system-ui, sans-serif;
+  --max-width: 1100px;
+}
+
+body {
+  color: var(--color-text);
+  background: var(--color-background);
+  font-family: var(--font-body);
+}
+```
+
+When a tenant overrides a variable, Station injects a `<style>` tag containing only the overrides. Theme defaults come from the theme's own CSS file — Station does not duplicate them inline.
+
+### Override precedence
+
+```
+:root { --color-accent: #e63946; }   <-- tenant override (inline <style>, highest)
+:root { --color-accent: #2563EB; }   <-- theme default (in app.css)
+                                       browser default (lowest)
+```
+
+Tenant overrides apply as long as the variable is still declared in the current theme's `theme.json`. If a theme update removes or renames a variable, stale overrides are silently dropped from render output — no runtime error, no data loss.
+
+## Templates
+
+The `templates` array declares which views the theme provides. The admin-side Content Type template selector reads from this list.
+
+```json
+"templates": ["layout", "homepage", "list", "detail", "page"]
+```
+
+Each entry must correspond to `views/{name}.blade.php`. Missing files produce a warning at validation time.
+
+### Custom templates
+
+Content Types can point at a custom template in the theme. Mark templates available to the dropdown by adding an annotation on line 1:
+
+```blade
+{{-- @station action: show --}}
+```
+
+Optionally add a display name:
+
+```blade
+{{-- @station name: 'Featured Event' --}}
+```
+
+Templates with `@station action: show` appear in the Content Type template selector. Missing templates fall back to `detail` at render time.
+
+### View namespace
+
+Blade views in the active theme are registered under the `theme::` namespace:
+
+```blade
+@extends('theme::layout')
+
+@section('content')
+  <article>…</article>
+@endsection
+```
+
+`FrontendController` registers the namespace on every request using the resolved theme's view path.
+
+### Shared view data
+
+Every frontend view receives these variables automatically:
+
+| Variable | Description |
+|----------|-------------|
+| `$siteName` | Tenant's site name. |
+| `$logoUrl` | URL of the tenant's logo, or `null`. |
+| `$activeTheme` | Slug of the resolved theme. |
+| `$theme` | `Theme` value object with `slug`, `name`, `version`, `viewPath`, `assetsPath`, etc. |
+| `$themeOverrideCss` | Rendered CSS string containing tenant overrides. Empty if none. |
+| `$primaryColor` | Legacy — the `primary_color` setting (still injected). |
+
+The layout should include the theme stylesheet and inject overrides:
+
+```blade
+<link rel="stylesheet" href="{{ $theme->publicCssUrl() }}">
+@if ($themeOverrideCss)
+<style>{!! $themeOverrideCss !!}</style>
+@endif
+```
+
+## Distribution
+
+### As a Composer package
+
+Publish a theme as a standalone Composer package. The package installer places the theme files in the Station `themes/` directory during install and triggers reconciliation.
+
+Your package should include:
+
+- `theme.json` at the package root.
+- `views/` and `assets/` folders.
+- A `composer.json` with appropriate metadata — see existing bundled themes for the pattern.
+
+Once published, add it to the Fissible package registry (or your own self-hosted registry) so platform admins can install it from the Themes page.
+
+### As a zip upload
+
+Non-technical admins can upload a theme as a `.zip` archive from the platform Themes page. The archive must:
+
+- Contain exactly one top-level directory named `{slug}/`, matching the `theme.json` slug.
+- Pass the security scan:
+  - No path traversal (`../`).
+  - Allowed extensions only: `.blade.php`, `.css`, `.js`, `.json`, `.jpg`, `.jpeg`, `.png`, `.svg`, `.webp`, `.woff`, `.woff2`, `.txt`, `.md`.
+  - No `.php` files outside `views/`.
+  - No executable files, no symlinks.
+- Be under the upload size limit (default 10MB, see `config/station.php`).
+
+On upload, Station extracts to a temp directory, validates the structure and manifest, then copies to the primary writable theme path.
+
+## Theme API versioning
+
+`theme_api` in the manifest declares which version of the Station theme contract the theme targets. Station 0.5 ships `theme_api: 1`. Future contract changes will bump this number.
+
+- **Forward compatibility:** A theme targeting `theme_api: 1` continues to work on any Station version that supports API 1.
+- **Breaking changes:** When Station introduces `theme_api: 2`, themes must opt in by bumping their declared API. API 1 themes continue to work alongside API 2 themes.
+
+## Failure modes
+
+Station's theme system degrades gracefully. Common failures and their runtime behavior:
+
+| Failure | Behavior |
+|---------|----------|
+| Tenant's `frontend_theme` points at a non-existent slug | Falls back through the resolution chain. Admin sees a warning banner in Site Settings. |
+| Theme was soft-removed by a platform admin | Same as above — tenants referring to the removed slug see the fallback. Overrides are preserved for recovery. |
+| Theme exists but `theme.json` is invalid | Theme is marked `invalid` at reconciliation. Tenants referring to it fall back; admin sees the warning. |
+| Content Type points at a template not declared by the current theme | Falls back to `detail`. A warning is logged. |
+| Tenant override references a variable no longer declared by the theme | Silently dropped from render output. Stored value preserved in case the variable returns. |
+
+## Reconciliation
+
+Station discovers themes on disk and syncs with DB metadata via **reconciliation**:
+
+- Reconciliation runs daily via the scheduler.
+- It also runs after any install/uninstall/upload.
+- Manual: `php artisan station:theme:reconcile [--slug=]`.
+
+The reconciliation report shows what changed (created, updated, missing, invalid, recovered). Run it after a manual file change if you want Station to pick up the update immediately.
+
+## Next steps
+
+- [Theme reference](/station/theme-reference/) — command and schema reference.
+- [Frontend & theming](/station/frontend-theming/) — template rendering, editorial bar, SEO.

--- a/docs/forge-deployment.md
+++ b/docs/forge-deployment.md
@@ -1,9 +1,13 @@
 # Forge Deployment
 
-This repo is deployed to one Forge-managed server with two sites:
+This repo is deployed to one Forge-managed server with two production sites:
 
 - `fissible.dev` — Laravel marketing application
 - `docs.fissible.dev` — static Astro/Starlight documentation site built from `apps/docs`
+
+Staging for the Laravel app is a third Forge site on the same server:
+
+- `staging.fissible.dev` — pre-production Laravel site deployed from the `staging` branch
 
 ## Server
 
@@ -23,6 +27,8 @@ Name.com records:
 | --- | --- | --- |
 | A | `fissible.dev` | Forge server IP |
 | CNAME | `www.fissible.dev` | `fissible.dev` |
+| A | `staging.fissible.dev` | Forge server IP |
+| A | `staging-app.fissible.dev` | Forge server IP |
 | A | `docs.fissible.dev` | Forge server IP |
 | MX | `fissible.dev` | Google Workspace records |
 
@@ -44,17 +50,24 @@ Deploy script:
 ```bash
 cd $FORGE_SITE_PATH
 
+# Maintenance mode — auto-recover if anything fails
+php artisan down --refresh=15
+trap 'php artisan up' ERR
+
 git pull origin $FORGE_SITE_BRANCH
 
 composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
 
-npm ci
+npm ci --ignore-scripts
 npm run build
 
+php artisan filament:assets
 php artisan migrate --force
 php artisan config:cache
 php artisan route:cache
 php artisan view:cache
+
+php artisan up
 ```
 
 Do not run `php artisan db:seed --force` as part of normal deploys. Seed manually only when specific seed data is required.
@@ -67,6 +80,81 @@ Production environment notes:
 - `LOG_LEVEL=info`
 - `STATION_PLATFORM_ENABLED=false` until platform auth/admin is production-ready
 - `MAIL_MAILER=log` is acceptable until real transactional email is needed
+
+## `staging.fissible.dev` Laravel Site
+
+Purpose: validate deploys, migrations, tenant provisioning, module installs,
+and theme changes without touching production data.
+
+Recommended Forge site settings:
+
+- Domain: `staging.fissible.dev`
+- Aliases: add `staging-app.fissible.dev` if you want a separate platform/app host
+- Repository: `fissible/fissible.dev`
+- Branch: `staging`
+- Web directory: `/public`
+- Database: separate MySQL database and user, e.g. `fissible_staging`
+- SSL: Let's Encrypt certificate covering `staging.fissible.dev` and `staging-app.fissible.dev` if both are used
+
+Git workflow:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b staging
+git push -u origin staging
+```
+
+If the `staging` branch already exists, keep it as the integration branch for
+pre-production deploys and merge or rebase from `main` intentionally.
+
+Staging environment overrides:
+
+- `APP_ENV=staging`
+- `APP_DEBUG=true`
+- `APP_URL=https://staging.fissible.dev`
+- `LOG_LEVEL=debug`
+- `STATION_PLATFORM_ENABLED=true`
+- `STATION_PLATFORM_HOST=staging-app.fissible.dev`
+- `STATION_MANAGED_ROOT_DOMAIN=staging.fissible.dev`
+- `DB_DATABASE=fissible_staging`
+- staging-specific DB username/password
+- safe mailer choice such as `MAIL_MAILER=log` until you intentionally test outbound email
+
+Use the same deploy script as production. The script uses `$FORGE_SITE_PATH`, so
+it works for both `fissible.dev` and `staging.fissible.dev` without path edits.
+
+First staging deploy checklist:
+
+1. Create the Forge site and connect it to the `staging` branch.
+2. Create the staging database and user.
+3. Paste the deploy script from [forge-deploy.sh](../forge-deploy.sh).
+4. Set the staging `.env` values in Forge.
+5. Deploy once.
+6. Run `php artisan key:generate` if the app key is still blank.
+7. Run `php artisan storage:link`.
+8. Run `php artisan station:make-admin you@fissible.dev`.
+
+Verification:
+
+```bash
+php artisan about
+php artisan migrate:status
+php artisan route:list | rg admin
+```
+
+Browser checks:
+
+- `https://staging.fissible.dev` loads the marketing site
+- `https://staging-app.fissible.dev/admin` loads the admin login if a separate app host is configured
+- production content and staging content do not share database state
+- pushing to `staging` deploys only the staging site
+
+Rollback / safety notes:
+
+- Do not point staging at the production database, even temporarily.
+- Keep `APP_DEBUG=true` only on staging, never production.
+- If you are not using `staging-app.fissible.dev`, leave `STATION_PLATFORM_HOST` set to the single host you actually serve.
 
 ## `docs.fissible.dev` Static Docs Site
 

--- a/docs/superpowers/plans/2026-04-14-station-webapp-scaffold.md
+++ b/docs/superpowers/plans/2026-04-14-station-webapp-scaffold.md
@@ -1,5 +1,7 @@
 # Station Web App Scaffold — Implementation Plan
 
+> **Superseded:** This plan describes the temporary `fissible.dev` Laravel shell. Current direction is to serve `fissible.dev` as a first-party tenant from the canonical Station app. See `docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Convert fissible.dev from static Astro sites to a Laravel application, port marketing content to Blade views, and prepare for Forge deployment.

--- a/docs/superpowers/plans/2026-04-14-tenant-provisioning-and-domains.md
+++ b/docs/superpowers/plans/2026-04-14-tenant-provisioning-and-domains.md
@@ -1,5 +1,7 @@
 # Station Tenant Provisioning and Domain Plan
 
+> **Superseded:** This plan describes the temporary `fissible.dev` Laravel shell. Current direction is to serve `fissible.dev` as a first-party tenant from the canonical Station app. See `docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md`.
+
 ## Goal
 
 Define how Station should handle:

--- a/docs/superpowers/plans/2026-04-15-phase2-station-app-structure.md
+++ b/docs/superpowers/plans/2026-04-15-phase2-station-app-structure.md
@@ -1,5 +1,7 @@
 # Phase 2: Station-Shaped App Structure — Implementation Plan
 
+> **Superseded:** This plan describes the temporary `fissible.dev` Laravel shell. Current direction is to serve `fissible.dev` as a first-party tenant from the canonical Station app. See `docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make fissible.dev a working Station instance with Filament admin, tenant subdomain rendering, and auth.

--- a/docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md
+++ b/docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md
@@ -1,0 +1,90 @@
+# Station Dogfood Handoff: fissible.dev vs station
+
+> **Read this first when working in `fissible/fissible.dev`.** This repo contains older plans that describe turning `fissible.dev` into a Station-shaped Laravel shell. That direction is now superseded.
+
+## Current Decision
+
+The canonical Station product lives in:
+
+`/Users/allenmccabe/lib/fissible/station`
+
+The production dogfood target is:
+
+- `fissible.dev` is a first-party Station tenant served by the canonical Station app.
+- `app.fissible.dev` is the Station control plane for login, admin, and platform management.
+- The current `fissible/fissible.dev` Laravel app is a temporary/reference shell. Do not add new Station product features here.
+
+The current Station-side implementation plan is:
+
+`/Users/allenmccabe/lib/fissible/station/docs/superpowers/plans/2026-04-15-first-party-tenant.md`
+
+That plan adds first-party tenant support, app-host routing, installer provisioning, a Fissible seeder suite, and a Fissible frontend theme scaffold.
+
+## Superseded Local Plans
+
+These local plans are historical context, not the current implementation direction:
+
+- `docs/superpowers/plans/2026-04-14-station-webapp-scaffold.md`
+- `docs/superpowers/plans/2026-04-14-tenant-provisioning-and-domains.md`
+- `docs/superpowers/plans/2026-04-15-phase2-station-app-structure.md`
+- `docs/superpowers/specs/2026-04-14-phase2-station-app-structure.md`
+
+They explain how the temporary Laravel shell got here, but they should not be used as the next-step plan for Station dogfooding.
+
+## What Not To Do
+
+- Do not port Station modules into this repo.
+- Do not keep building tenant CMS, forms, lead management, subscriptions, content blocks, or platform management in this repo.
+- Do not treat this repo's simple `Tenant`, `TenantPage`, `TenantMenu`, or `is_platform_admin` implementation as the future Station architecture.
+- Do not split the product into a custom `fissible.dev` Laravel app plus a separate Station app unless the user explicitly reverses the dogfood decision.
+
+## What To Do Next
+
+Work in `/Users/allenmccabe/lib/fissible/station`.
+
+1. Verify the first-party tenant plan is fully implemented:
+   - `php artisan test --filter=FirstPartyTenantTest`
+   - `php artisan theme:list`
+   - check `config/station.php` for `app_host` and `first_party`
+   - check `StationInstall` for configured first-party slug lookups instead of hard-coded `default`
+
+2. Add or update a Station project handoff after verification:
+   - update `/Users/allenmccabe/lib/fissible/station/PROJECT.md`
+   - note that `2026-04-15-first-party-tenant.md` is the canonical dogfood plan
+   - include remaining blockers and exact test results
+
+3. Migrate Fissible public content from this repo into Station:
+   - use this repo's Blade views/config/assets as source material
+   - move real content into Station entries, blocks, menus, and the Fissible theme
+   - keep this repo as reference until Station serves `fissible.dev`
+
+4. Prepare production routing:
+   - `fissible.dev` -> Station public tenant frontend
+   - `www.fissible.dev` -> same first-party tenant or redirect to apex
+   - `app.fissible.dev` -> Station control plane
+   - optional wildcard `*.fissible.dev` -> Station for demo/client tenants
+
+5. After Station serves the public site, archive or decommission this temporary app.
+
+## Open Product Work After Dogfood Bootstrapping
+
+These are Station features to build in the canonical Station repo as dogfooding exposes the need:
+
+- Real Fissible theme polish and content migration
+- Blog module
+- Forms/contact lead capture wiring
+- Lead management
+- Per-tenant theme selection before external clients use the same install with non-Fissible themes
+- Subscription/customer portal features
+- Public demo tenant such as `station-demo.fissible.dev`
+
+## Mental Model
+
+There should be one product implementation:
+
+`Station app -> many tenants -> Fissible is first-party tenant`
+
+There should not be two competing implementations:
+
+`custom fissible.dev app + separate Station app`
+

--- a/docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md
+++ b/docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md
@@ -1,6 +1,6 @@
 # Station Dogfood Handoff: fissible.dev vs station
 
-> **Read this first when working in `fissible/fissible.dev`.** This repo contains older plans that describe turning `fissible.dev` into a Station-shaped Laravel shell. That direction is now superseded.
+> **Read this first when working in `fissible/fissible.dev`.** This repo is the site/overlay source for the Fissible brand and first-party Station tenant. Do not use the older shell migration plans as the current implementation direction.
 
 ## Current Decision
 
@@ -12,7 +12,7 @@ The production dogfood target is:
 
 - `fissible.dev` is a first-party Station tenant served by the canonical Station app.
 - `app.fissible.dev` is the Station control plane for login, admin, and platform management.
-- The current `fissible/fissible.dev` Laravel app is a temporary/reference shell. Do not add new Station product features here.
+- This repo supplies the Fissible site overlay, marketing content, and related assets for that tenant. Keep Station product logic in `fissible/station`.
 
 The current Station-side implementation plan is:
 
@@ -29,12 +29,12 @@ These local plans are historical context, not the current implementation directi
 - `docs/superpowers/plans/2026-04-15-phase2-station-app-structure.md`
 - `docs/superpowers/specs/2026-04-14-phase2-station-app-structure.md`
 
-They explain how the temporary Laravel shell got here, but they should not be used as the next-step plan for Station dogfooding.
+They explain how the site overlay was originally scaffolded, but they should not be used as the next-step plan for Station work.
 
 ## What Not To Do
 
 - Do not port Station modules into this repo.
-- Do not keep building tenant CMS, forms, lead management, subscriptions, content blocks, or platform management in this repo.
+- Do not rebuild tenant CMS, forms, lead management, subscriptions, content blocks, or platform management here.
 - Do not treat this repo's simple `Tenant`, `TenantPage`, `TenantMenu`, or `is_platform_admin` implementation as the future Station architecture.
 - Do not split the product into a custom `fissible.dev` Laravel app plus a separate Station app unless the user explicitly reverses the dogfood decision.
 
@@ -44,7 +44,7 @@ Work in `/Users/allenmccabe/lib/fissible/station`.
 
 1. Verify the first-party tenant plan is fully implemented:
    - `php artisan test --filter=FirstPartyTenantTest`
-   - `php artisan theme:list`
+   - `php artisan station:theme:list`
    - check `config/station.php` for `app_host` and `first_party`
    - check `StationInstall` for configured first-party slug lookups instead of hard-coded `default`
 
@@ -64,7 +64,7 @@ Work in `/Users/allenmccabe/lib/fissible/station`.
    - `app.fissible.dev` -> Station control plane
    - optional wildcard `*.fissible.dev` -> Station for demo/client tenants
 
-5. After Station serves the public site, archive or decommission this temporary app.
+5. After Station serves the public site, keep this repo as the site overlay/reference unless the product direction changes.
 
 ## Open Product Work After Dogfood Bootstrapping
 
@@ -87,4 +87,3 @@ There should be one product implementation:
 There should not be two competing implementations:
 
 `custom fissible.dev app + separate Station app`
-

--- a/docs/superpowers/specs/2026-04-14-phase2-station-app-structure.md
+++ b/docs/superpowers/specs/2026-04-14-phase2-station-app-structure.md
@@ -1,5 +1,7 @@
 # Phase 2: Station-Shaped App Structure
 
+> **Superseded:** This spec describes the temporary `fissible.dev` Laravel shell. Current direction is to serve `fissible.dev` as a first-party tenant from the canonical Station app. See `docs/superpowers/plans/2026-04-15-station-dogfood-handoff.md`.
+
 **Goal:** Make fissible.dev a working Station instance where tenants have real
 public sites, the admin panel works, and new Station features can land without
 restructuring the repo.

--- a/forge-deploy.sh
+++ b/forge-deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Forge deployment script for fissible.dev
+# Forge deployment script for fissible.dev / staging.fissible.dev
 # Copy this into Forge > Site > Deploy Script
 #
 # Requirements:
@@ -14,12 +14,15 @@
 #   3. Create storage symlink: php artisan storage:link
 #   4. Run initial migration: php artisan migrate --force
 #   5. Create admin user: php artisan station:make-admin admin@fissible.dev
-#   6. Enable wildcard subdomains in Forge site settings
-#   7. Add *.fissible.dev wildcard DNS A record
+#   6. For staging, point APP_URL at https://staging.fissible.dev and use a
+#      separate database + branch
+#   7. Enable wildcard subdomains in Forge site settings only if the site will
+#      host tenant subdomains
+#   8. Add any required DNS records before requesting Let's Encrypt
 
 set -e
 
-cd /home/forge/fissible.dev
+cd "$FORGE_SITE_PATH"
 
 # Maintenance mode — auto-recover if anything fails
 php artisan down --refresh=15

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -723,3 +723,71 @@ pre {
 .coming-soon-page .waitlist-section { margin-top: 2.5rem; }
 .coming-soon-page .waitlist-section h2 { font-size: 0.875rem; font-weight: 600; color: var(--text-muted); margin-bottom: 1rem; }
 .coming-soon-page .waitlist-form { justify-content: center; }
+
+/* ---------- Footer ---------- */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 2.5rem 2rem;
+  margin-top: var(--space-section);
+}
+.footer-inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.footer-avatar {
+  border-radius: 50%;
+  border: 1px solid var(--border);
+}
+.footer-brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.footer-company {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.footer-domain {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.footer-domain:hover { color: var(--accent); }
+.footer-contact {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+.footer-address {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.footer-phone {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.footer-phone:hover { color: var(--accent); }
+.footer-links {
+  display: flex;
+  gap: 1.25rem;
+}
+.footer-links a {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+.footer-links a:hover { color: var(--text); }
+@media (max-width: 600px) {
+  .footer-inner { flex-direction: column; align-items: flex-start; gap: 1.25rem; }
+  .footer-contact { align-items: flex-start; }
+}

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,19 @@
+<footer class="site-footer">
+    <div class="footer-inner">
+        <div class="footer-brand">
+            <img src="https://avatars.githubusercontent.com/u/1410914?s=36" alt="Fissible" class="footer-avatar" width="36" height="36">
+            <div class="footer-brand-text">
+                <span class="footer-company">Fissible LLC</span>
+                <a href="https://fissible.dev" class="footer-domain">fissible.dev</a>
+            </div>
+        </div>
+        <div class="footer-contact">
+            <span class="footer-address">2108 N St, Ste N, Sacramento, CA 95816</span>
+            <a href="tel:+16615363720" class="footer-phone">(661) 536-3720</a>
+        </div>
+        <div class="footer-links">
+            <a href="https://github.com/fissible" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href="https://docs.fissible.dev">Docs</a>
+        </div>
+    </div>
+</footer>

--- a/resources/views/components/layouts/marketing.blade.php
+++ b/resources/views/components/layouts/marketing.blade.php
@@ -14,5 +14,6 @@
     <main>
         {{ $slot }}
     </main>
+    <x-footer />
 </body>
 </html>

--- a/resources/views/components/tenant/layout.blade.php
+++ b/resources/views/components/tenant/layout.blade.php
@@ -22,5 +22,6 @@
     <main>
         {{ $slot }}
     </main>
+    <x-footer />
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make the Forge deploy script safe for both production and staging by using ``
- document the `staging.fissible.dev` Forge/DNS/database/environment setup
- add staging-specific env override examples for the current fissible.dev deployment model

## Testing
- bash -n forge-deploy.sh

Refs fissible/station#93